### PR TITLE
[#21 Bug] Fix : Credits stops working after a client is dropping early.

### DIFF
--- a/addons/sourcemod/scripting/mystore_misc_earnings.sp
+++ b/addons/sourcemod/scripting/mystore_misc_earnings.sp
@@ -242,13 +242,18 @@ public void MyStore_OnConfigExecuted(ConVar enable, char[] name, char[] prefix, 
 	gc_bFFA = FindConVar("mp_teammates_are_enemies");
 }
 
+public void OnClientConnected(int client)
+{
+    if (!IsFakeClient(client))
+        g_iClientCount++;
+}
+
 public void OnClientPostAdminCheck(int client)
 {
 	SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);
 	if (IsFakeClient(client))
 		return;
 
-	g_iClientCount++;
 	g_iActive[client] = 0;
 	g_iSum[client] = 0;
 	g_fClientMulti[client] = 1.0;


### PR DESCRIPTION
This is a bug fix for #21.

**Explanation:**
When a client is connecting, he can disconnect (drop from the server) before reaching the `OnClientPostAdminCheck()` forward, which results an unwanted behavior, he doesn't add up into the count variable (`g_iClientCount`) but makes the counter subtract 1 from it when he reaches the `OnClientDisconnect()` forward.

This can cause the the counter to be wrong.
This result a wrong outcome in the minimum players checks.
and because of that, credits are not being added. ([for example in here](https://github.com/shanapu/MyStore/blob/b9fed6da7646f7acb3ad7ffce1c01914186317ef/addons/sourcemod/scripting/mystore_misc_earnings.sp#L456))

Thanks for @penalte for testing and confirming #21 bug is resolved.